### PR TITLE
Add user management and authentication

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -2,10 +2,14 @@
 
 A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
 
+
 ## Features
 
 - View all available extracurricular activities
 - Sign up for activities
+- User authentication (admin, staff, student)
+- Login/logout endpoints
+- Session-based user info endpoint
 
 ## Getting Started
 
@@ -25,26 +29,28 @@ A super simple FastAPI application that allows students to view and sign up for 
    - API documentation: http://localhost:8000/docs
    - Alternative documentation: http://localhost:8000/redoc
 
+
 ## API Endpoints
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/login`                                                          | Log in as a user (form: username, password)                         |
+| POST   | `/logout`                                                         | Log out the current user                                            |
+| GET    | `/me`                                                             | Get info about the current logged-in user                           |
+
 
 ## Data Model
 
 The application uses a simple data model with meaningful identifiers:
 
-1. **Activities** - Uses activity name as identifier:
-
+1. **Users** - username, password, and role (admin, staff, student)
+2. **Sessions** - session_id cookie maps to username
+3. **Activities** - Uses activity name as identifier:
    - Description
    - Schedule
    - Maximum number of participants allowed
    - List of student emails who are signed up
-
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.


### PR DESCRIPTION
This PR adds basic user management and authentication endpoints (login/logout) to the backend, including:
- In-memory user store with roles (admin, staff, student)
- Session-based login/logout endpoints
- `/me` endpoint to get current user info
- Updated README with new features and API documentation

This is a foundational step for future role-based access and security improvements.